### PR TITLE
Test: add --nocapture flag support

### DIFF
--- a/kongswap_adaptor/tests/e2e.rs
+++ b/kongswap_adaptor/tests/e2e.rs
@@ -224,11 +224,11 @@ async fn e2e_test() {
     assert_eq!(balances_after_second_upgrade, balances_before_upgrade);
     assert_eq!(audit_trail_after_second_upgrade, audit_trail_before_upgrade);
 
-    // use kongswap_adaptor::audit::serialize_audit_trail;
-    // panic!(
-    //     "audit_trail = {}",
-    //     serialize_audit_trail(&audit_trail_after_second_upgrade, true).unwrap()
-    // );
+    use kongswap_adaptor::audit::serialize_audit_trail;
+    println!(
+        "audit_trail = {}",
+        serialize_audit_trail(&audit_trail_after_second_upgrade, true).unwrap()
+    );
 }
 
 async fn create_kong_adaptor(pocket_ic: &PocketIc, subnet_id: Principal) -> Principal {

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -38,7 +38,8 @@ def main():
                        help='Run tests with verbose output')
     parser.add_argument('--test-name', type=str, 
                        help='Run specific test by name')
-    
+    parser.add_argument('--nocapture', action= 'store_true', help='Runs tests with `--no-capture` flag')
+
     args = parser.parse_args()
     
     # Get project paths
@@ -80,7 +81,9 @@ def main():
     
     if args.test_name:
         cargo_test_cmd.append(args.test_name)
-    
+
+    if args.nocapture:
+        cargo_test_cmd.extend(["--", "--nocapture"])
     # Run tests
     print(f"Running tests: {' '.join(cargo_test_cmd)}")
     


### PR DESCRIPTION
This PR adds the possibility of running the test scripts with `--nocapture` flag. It disables the output of the tests being captured and allows the output of `println!` to be shown in the terminal.