### PR TITLE
Fix: accounting on retrial

### DIFF
--- a/kongswap_adaptor/src/withdraw.rs
+++ b/kongswap_adaptor/src/withdraw.rs
@@ -168,6 +168,12 @@ impl<A: AbstractAgent> KongSwapAdaptor<A> {
                     ..
                 }) => {
                     if let Some(asset) = self.get_asset_for_ledger(&canister_id) {
+                        let (balances_before, balances_after) = if asset == self.assets().0 {
+                            (balances_before.0, balances_after.0)
+                        } else {
+                            (balances_before.1, balances_after.1)
+                        };
+
                         match decode_nat_to_u64(amount) {
                             Ok(amount) => {
                                 self.move_asset(
@@ -178,8 +184,8 @@ impl<A: AbstractAgent> KongSwapAdaptor<A> {
                                 );
                                 self.find_discrepency(
                                     asset,
-                                    balances_before.0,
-                                    balances_after.0,
+                                    balances_before,
+                                    balances_after,
                                     amount,
                                     false,
                                 );
@@ -253,3 +259,6 @@ mod withdraw_happy_path;
 
 #[cfg(test)]
 mod withdraw_retry;
+
+#[cfg(test)]
+mod withdraw_failed_dex_withdraw;


### PR DESCRIPTION
In < [Previous PR](https://github.com/dfinity/sns-kongswap-adaptor/pull/44) | a regression test was added which revealed that in `retry_withdraw_from_dex()` the balance comparison was hardcoded to the balances of asset 0. This PR solves this error.