### PR TITLE
Fix: refreshing the external custodian at the beginning of each withdrawal

### DIFF
--- a/kongswap_adaptor/src/balances.rs
+++ b/kongswap_adaptor/src/balances.rs
@@ -517,15 +517,19 @@ impl<A: AbstractAgent> KongSwapAdaptor<A> {
             .await?;
 
         let RemoveLiquidityAmountsReply {
-            amount_0, amount_1, ..
+            amount_0,
+            amount_1,
+            lp_fee_0,
+            lp_fee_1,
+            ..
         } = reply;
 
-        let balance_0_decimals = decode_nat_to_u64(amount_0).map_err(|err| Error {
+        let balance_0_decimals = decode_nat_to_u64(amount_0 + lp_fee_0).map_err(|err| Error {
             code: u64::from(TransactionErrorCodes::PostConditionCode),
             message: err.clone(),
             kind: ErrorKind::Postcondition {},
         })?;
-        let balance_1_decimals = decode_nat_to_u64(amount_1).map_err(|err| Error {
+        let balance_1_decimals = decode_nat_to_u64(amount_1 + lp_fee_1).map_err(|err| Error {
             code: u64::from(TransactionErrorCodes::PostConditionCode),
             message: err.clone(),
             kind: ErrorKind::Postcondition {},

--- a/kongswap_adaptor/src/canister.rs
+++ b/kongswap_adaptor/src/canister.rs
@@ -142,6 +142,12 @@ impl<A: AbstractAgent> TreasuryManager for KongSwapAdaptor<A> {
     async fn withdraw(&mut self, request: WithdrawRequest) -> TreasuryManagerResult {
         self.check_state_lock()?;
 
+        // We refresh the external custodian balances, as it could
+        // be unknown to the treasury manager, whether an external
+        // trader has swapped their tokens on the pool and consequently
+        // changes the balances or not.
+        self.refresh_balances().await;
+
         let (ledger_0, ledger_1) = self.ledgers();
 
         let (default_owner_0, default_owner_1) = self.owner_accounts();

--- a/kongswap_adaptor/src/test_helpers/mod.rs
+++ b/kongswap_adaptor/src/test_helpers/mod.rs
@@ -14,8 +14,8 @@ use crate::{
     kong_types::{
         AddLiquidityAmountsArgs, AddLiquidityAmountsReply, AddLiquidityArgs, AddLiquidityReply,
         AddPoolArgs, AddPoolReply, AddTokenArgs, AddTokenReply, ClaimReply, ClaimsReply, ICReply,
-        RemoveLiquidityArgs, RemoveLiquidityReply, UserBalanceLPReply, UserBalancesArgs,
-        UserBalancesReply,
+        RemoveLiquidityAmountsArgs, RemoveLiquidityAmountsReply, RemoveLiquidityArgs,
+        RemoveLiquidityReply, UserBalanceLPReply, UserBalancesArgs, UserBalancesReply,
     },
     validation::{decode_nat_to_u64, ValidatedAsset},
     KONG_BACKEND_CANISTER_ID,
@@ -357,6 +357,35 @@ pub(crate) fn make_add_liquidity_reply(
         amount_0: Nat::from(amount_0),
         symbol_1: symbol_1.to_string(),
         amount_1: Nat::from(amount_1),
+        ..Default::default()
+    }
+}
+
+pub(crate) fn make_remove_liquidity_amount_request(
+    token_0: String,
+    token_1: String,
+    remove_lp_token_amount: u64,
+) -> RemoveLiquidityAmountsArgs {
+    RemoveLiquidityAmountsArgs {
+        token_0,
+        token_1,
+        remove_lp_token_amount: Nat::from(remove_lp_token_amount),
+    }
+}
+
+pub(crate) fn make_remove_liquidity_amount_reply(
+    amount_0: u64,
+    lp_fee_0: u64,
+    amount_1: u64,
+    lp_fee_1: u64,
+    remove_lp_token_amount: u64,
+) -> RemoveLiquidityAmountsReply {
+    RemoveLiquidityAmountsReply {
+        amount_0: Nat::from(amount_0),
+        lp_fee_0: Nat::from(lp_fee_0),
+        amount_1: Nat::from(amount_1),
+        lp_fee_1: Nat::from(lp_fee_1),
+        remove_lp_token_amount: Nat::from(remove_lp_token_amount),
         ..Default::default()
     }
 }

--- a/kongswap_adaptor/src/withdraw/test/withdraw_happy_path.rs
+++ b/kongswap_adaptor/src/withdraw/test/withdraw_happy_path.rs
@@ -75,6 +75,26 @@ async fn test_withdraw_success() {
                 100.0,
             )]),
         )
+        .add_call(
+            *KONG_BACKEND_CANISTER_ID,
+            make_remove_liquidity_amount_request(SYMBOL_0.clone(), SYMBOL_1.clone(), 100 * E8),
+            Ok(make_remove_liquidity_amount_reply(
+                amount_0_decimals - 2 * FEE_SNS,
+                0,
+                amount_1_decimals - 2 * FEE_ICP,
+                0,
+                100 * E8,
+            )),
+        )
+        .add_call(
+            *KONG_BACKEND_CANISTER_ID,
+            make_lp_balance_request(),
+            Ok(vec![make_lp_balance_reply(
+                SYMBOL_0.clone(),
+                SYMBOL_1.clone(),
+                100.0,
+            )]),
+        )
         .add_call(*SNS_LEDGER, make_balance_request(), Nat::from(0_u64))
         .add_call(*ICP_LEDGER, make_balance_request(), Nat::from(0_u64))
         .add_call(

--- a/kongswap_adaptor/src/withdraw/test/withdraw_retry.rs
+++ b/kongswap_adaptor/src/withdraw/test/withdraw_retry.rs
@@ -94,6 +94,26 @@ async fn test_withdraw_retry() {
             *KONG_BACKEND_CANISTER_ID,
             make_lp_balance_request(),
             Ok(vec![make_lp_balance_reply(
+                SYMBOL_0.clone(),
+                SYMBOL_1.clone(),
+                100.0,
+            )]),
+        )
+        .add_call(
+            *KONG_BACKEND_CANISTER_ID,
+            make_remove_liquidity_amount_request(SYMBOL_0.clone(), SYMBOL_1.clone(), 100 * E8),
+            Ok(make_remove_liquidity_amount_reply(
+                amount_0_decimals - 2 * FEE_SNS,
+                0,
+                amount_1_decimals - 2 * FEE_ICP,
+                0,
+                100 * E8,
+            )),
+        )
+        .add_call(
+            *KONG_BACKEND_CANISTER_ID,
+            make_lp_balance_request(),
+            Ok(vec![make_lp_balance_reply(
                 symbol_0.clone(),
                 symbol_1.clone(),
                 0.0,


### PR DESCRIPTION
As external users can swap their tokens in the pool, the balance of the tokens in external pool changes. This is however unknown to the treasury manager. Hence, before starting a withdrawal, it should update the balance of the DEX.