### PR TITLE
Shah/remove deprecated functions

### DIFF
--- a/kongswap_adaptor/src/agent/ic_cdk_agent.rs
+++ b/kongswap_adaptor/src/agent/ic_cdk_agent.rs
@@ -1,5 +1,6 @@
 use super::{AbstractAgent, Request};
 use candid::Principal;
+use ic_cdk::call::{CallFailed, CandidDecodeFailed};
 use thiserror::Error;
 
 pub struct CdkAgent {}
@@ -12,12 +13,12 @@ impl CdkAgent {
 
 #[derive(Error, Debug)]
 pub enum CdkAgentError {
-    #[error("ic_cdk error code {0}: {1}")]
-    IcCdk(i32, String),
+    #[error(transparent)]
+    CallFailed(#[from] CallFailed),
     #[error("canister request could not be encoded: {0}")]
     CandidEncode(candid::Error),
-    #[error("canister did not respond with the expected response type: {0}")]
-    CandidDecode(candid::Error),
+    #[error(transparent)]
+    CandidDecode(#[from] CandidDecodeFailed),
 }
 
 impl AbstractAgent for CdkAgent {
@@ -28,17 +29,16 @@ impl AbstractAgent for CdkAgent {
         canister_id: impl Into<Principal> + Send,
         request: R,
     ) -> Result<R::Response, Self::Error> {
-        let args_raw = request.payload().map_err(CdkAgentError::CandidEncode)?;
+        let raw_args = request.payload().map_err(CdkAgentError::CandidEncode)?;
 
-        let response =
-            ic_cdk::api::call::call_raw(canister_id.into(), request.method(), args_raw, 0)
-                .await
-                .map_err(|(err_code, err_message)| {
-                    CdkAgentError::IcCdk(err_code as i32, err_message)
-                })?;
+        let call_response =
+            ic_cdk::call::Call::unbounded_wait(canister_id.into(), request.method())
+                .take_raw_args(raw_args)
+                .await?;
 
-        let result =
-            candid::decode_one(response.as_slice()).map_err(CdkAgentError::CandidDecode)?;
+        let result = call_response
+            .candid::<<R as Request>::Response>()
+            .map_err(|err| CdkAgentError::CandidDecode(err.into()))?;
 
         Ok(result)
     }

--- a/kongswap_adaptor/src/canister.rs
+++ b/kongswap_adaptor/src/canister.rs
@@ -87,16 +87,16 @@ fn canister_state() -> KongSwapAdaptor<CdkAgent> {
     KongSwapAdaptor::new(
         time_ns,
         CdkAgent::new(),
-        ic_cdk::id(),
+        ic_cdk::api::canister_self(),
         &BALANCES,
         &AUDIT_TRAIL,
     )
 }
 
 fn check_access() {
-    let caller = ic_cdk::api::caller();
+    let caller = ic_cdk::api::msg_caller();
 
-    if caller == ic_cdk::id() {
+    if caller == ic_cdk::api::canister_self() {
         return;
     }
 
@@ -110,14 +110,14 @@ fn check_access() {
 // Inspect the ingress messages in the pre-consensus phase and reject unauthorized access early.
 #[inspect_message]
 fn inspect_message() {
-    let method_name = ic_cdk::api::call::method_name();
+    let method_name = ic_cdk::api::msg_method_name();
 
     // Queries can be called by anyone, even if they are called as updates.
     if !["balances", "audit_trail"].contains(&method_name.as_str()) {
         check_access();
     }
 
-    ic_cdk::api::call::accept_message();
+    ic_cdk::api::accept_message();
 }
 
 declare_log_buffer!(name = LOG, capacity = 100);
@@ -130,7 +130,7 @@ fn log(msg: &str) {
     let msg = format!("[KongSwapAdaptor] {}", msg);
 
     if cfg!(target_arch = "wasm32") {
-        ic_cdk::print(&msg);
+        ic_cdk::api::debug_print(&msg);
     } else {
         println!("{}", msg);
     }
@@ -319,7 +319,7 @@ async fn run_periodic_tasks() {
 
 fn init_periodic_tasks() {
     let _new_timer_id = ic_cdk_timers::set_timer_interval(RUN_PERIODIC_TASKS_INTERVAL, || {
-        ic_cdk::spawn(run_periodic_tasks())
+        ic_cdk::futures::spawn(run_periodic_tasks())
     });
 }
 
@@ -330,21 +330,26 @@ async fn init_async(allowance_0: Allowance, allowance_1: Allowance) {
         allowances: vec![allowance_0, allowance_1],
     };
 
-    let result: Result<(TreasuryManagerResult,), _> =
-        ic_cdk::call(ic_cdk::id(), "deposit", (request,)).await;
+    let call_result = ic_cdk::call::Call::unbounded_wait(ic_cdk::api::canister_self(), "deposit")
+        .with_arg(request)
+        .await;
 
-    let result = match result {
+    let call_response = match call_result {
         Ok(result) => result,
-        Err((err_code, err_message)) => {
-            log_err(&format!(
-                "Self-call failed in async initializition. Error code {}: {:?}",
-                err_code as i32, err_message,
-            ));
+        Err(call_failed) => {
+            let error_message = format!(
+                "Self-call failed in async initialization due to: {}",
+                call_failed
+            );
+            log_err(&error_message);
             return;
         }
     };
 
-    if let Err(err) = result.0 {
+    let result: Result<(TreasuryManagerResult,), Vec<sns_treasury_manager::Error>> =
+        call_response.candid().unwrap();
+
+    if let Err(err) = result {
         log_err(&format!("Initial deposit failed: {:?}", err));
         return;
     }
@@ -383,7 +388,7 @@ async fn canister_init(arg: TreasuryManagerArg) {
     let allowance_1 = Allowance::from(allowance_1);
 
     ic_cdk_timers::set_timer(Duration::ZERO, || {
-        ic_cdk::spawn(init_async(allowance_0, allowance_1))
+        ic_cdk::futures::spawn(init_async(allowance_0, allowance_1))
     });
 }
 

--- a/kongswap_adaptor/tests/approval.rs
+++ b/kongswap_adaptor/tests/approval.rs
@@ -1,0 +1,119 @@
+mod common;
+
+use candid::{Decode, Encode, Nat};
+use icrc_ledger_types::icrc1::account::Account;
+use pocket_ic::PocketIcBuilder;
+use pretty_assertions::assert_eq;
+use std::time::Duration;
+
+use crate::common::{
+    pocket_ic_agent::PocketIcAgent,
+    utils::{
+        approve_tokens, create_kong_adaptor, install_sns_ledger, mint_tokens, E8, FEE_SNS,
+        SNS_GOVERNANCE_CANISTER_ID, TREASURY_SNS_ACCOUNT,
+    },
+};
+
+#[tokio::test]
+async fn allowance_overwrite_test() {
+    // Prepare the world.
+    let pocket_ic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_sns_subnet()
+        .with_fiduciary_subnet()
+        .build_async()
+        .await;
+
+    let mut agent = PocketIcAgent::new(pocket_ic);
+    let sns_amount = 100 * E8;
+    let sns_approval = 10 * E8;
+
+    let topology = agent.pic().topology().await;
+    let fiduciary_subnet_id = topology.get_fiduciary().unwrap();
+
+    let kong_adaptor_canister_id = create_kong_adaptor(&agent.pic(), fiduciary_subnet_id).await;
+    let sns_ledger_canister_id = install_sns_ledger(&agent.pic()).await;
+
+    for _ in 0..10 {
+        agent.pic().tick().await;
+        agent.pic().advance_time(Duration::from_secs(10)).await;
+    }
+
+    mint_tokens(
+        agent.with_sender(*SNS_GOVERNANCE_CANISTER_ID),
+        sns_ledger_canister_id,
+        Account {
+            owner: TREASURY_SNS_ACCOUNT.owner.clone(),
+            subaccount: TREASURY_SNS_ACCOUNT.subaccount.clone(),
+        },
+        sns_amount,
+    )
+    .await;
+
+    for _ in 0..10 {
+        agent.pic().tick().await;
+        agent.pic().advance_time(Duration::from_secs(10)).await;
+    }
+
+    approve_tokens(
+        agent.with_sender(*SNS_GOVERNANCE_CANISTER_ID),
+        sns_ledger_canister_id,
+        Account {
+            owner: kong_adaptor_canister_id,
+            subaccount: None,
+        },
+        sns_approval,
+        FEE_SNS,
+        TREASURY_SNS_ACCOUNT.subaccount.clone(),
+    )
+    .await;
+
+    for _ in 0..10 {
+        agent.pic().tick().await;
+        agent.pic().advance_time(Duration::from_secs(10)).await;
+    }
+
+    approve_tokens(
+        agent.with_sender(*SNS_GOVERNANCE_CANISTER_ID),
+        sns_ledger_canister_id,
+        Account {
+            owner: kong_adaptor_canister_id,
+            subaccount: None,
+        },
+        sns_approval,
+        FEE_SNS,
+        TREASURY_SNS_ACCOUNT.subaccount.clone(),
+    )
+    .await;
+
+    for _ in 0..10 {
+        agent.pic().tick().await;
+        agent.pic().advance_time(Duration::from_secs(10)).await;
+    }
+
+    let request = icrc_ledger_types::icrc2::allowance::AllowanceArgs {
+        account: Account {
+            owner: TREASURY_SNS_ACCOUNT.owner.clone(),
+            subaccount: TREASURY_SNS_ACCOUNT.subaccount.clone(),
+        },
+        spender: Account {
+            owner: kong_adaptor_canister_id,
+            subaccount: None,
+        },
+    };
+
+    let allowance = agent
+        .pic()
+        .query_call(
+            sns_ledger_canister_id.into(),
+            *SNS_GOVERNANCE_CANISTER_ID,
+            "icrc2_allowance",
+            Encode!(&request).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let allowance = Decode!(&allowance, icrc_ledger_types::icrc2::allowance::Allowance).unwrap();
+
+    assert_eq!(allowance.allowance, Nat::from(sns_approval - FEE_SNS));
+}


### PR DESCRIPTION
This PR replaces deprecated `ic_cdk functions` with their recommended alternatives after upgrading to `0.18.6`.