### PR TITLE
Shah/fix error matching

### DIFF
--- a/kongswap_adaptor/src/balances.rs
+++ b/kongswap_adaptor/src/balances.rs
@@ -43,7 +43,7 @@ impl Display for Party {
     }
 }
 
-#[derive(CandidType, Deserialize, Clone)]
+#[derive(CandidType, Deserialize, Clone, Debug)]
 pub(crate) struct ValidatedBalanceBook {
     pub treasury_owner: ValidatedBalance,
     pub treasury_manager: ValidatedBalance,

--- a/kongswap_adaptor/src/deposit/mod.rs
+++ b/kongswap_adaptor/src/deposit/mod.rs
@@ -221,6 +221,8 @@ impl<A: AbstractAgent> KongSwapAdaptor<A> {
 
         let result = self.add_pool(context, allowance_0, allowance_1).await;
 
+        log_err(&format!("add_ppol: {:#?}", result));
+
         if let Err(Error {
             kind: ErrorKind::Backend {},
             message,
@@ -235,6 +237,7 @@ impl<A: AbstractAgent> KongSwapAdaptor<A> {
                     .await
                     .map_err(|err| vec![err])?;
             } else {
+                log_err("Adding pool really failed");
                 // It corresponds to a failed transfer from call.
                 let balances_after = self.get_ledger_balances(context).await?;
 
@@ -434,11 +437,21 @@ impl<A: AbstractAgent> KongSwapAdaptor<A> {
         {
             self.add_manager_balance(allowance_0.asset, allowance_0.amount_decimals);
             self.add_manager_balance(allowance_1.asset, allowance_1.amount_decimals);
+            log_err(&format!(
+                "manager balance_0 {}, manager balance_1 {}",
+                allowance_0.amount_decimals, allowance_1.amount_decimals,
+            ));
         }
 
         let deposit_into_dex_result = self
             .deposit_into_dex(context, allowance_0, allowance_1)
             .await;
+
+        log_err("After depositing with failure into DEX");
+        self.with_balances_mut(|balances| {
+            log_err(&format!("asset_0_balance: {:#?}", balances.asset_0_balance));
+            log_err(&format!("asset_1_balance: {:#?}", balances.asset_1_balance));
+        });
 
         let returned_amounts_result = self
             .return_remaining_assets_to_owner(

--- a/kongswap_adaptor/src/deposit/mod.rs
+++ b/kongswap_adaptor/src/deposit/mod.rs
@@ -221,10 +221,8 @@ impl<A: AbstractAgent> KongSwapAdaptor<A> {
 
         let result = self.add_pool(context, allowance_0, allowance_1).await;
 
-        log_err(&format!("add_ppol: {:#?}", result));
-
         if let Err(Error {
-            kind: ErrorKind::Backend {},
+            kind: _,
             message,
             code,
         }) = result
@@ -237,7 +235,6 @@ impl<A: AbstractAgent> KongSwapAdaptor<A> {
                     .await
                     .map_err(|err| vec![err])?;
             } else {
-                log_err("Adding pool really failed");
                 // It corresponds to a failed transfer from call.
                 let balances_after = self.get_ledger_balances(context).await?;
 
@@ -257,7 +254,7 @@ impl<A: AbstractAgent> KongSwapAdaptor<A> {
                 );
 
                 log_err(&format!(
-                    "Transferring one of the tokens from the manager to the DEX failed: {}",
+                    "Deposting into DEX failed with the message: {}",
                     message
                 ));
 
@@ -437,21 +434,11 @@ impl<A: AbstractAgent> KongSwapAdaptor<A> {
         {
             self.add_manager_balance(allowance_0.asset, allowance_0.amount_decimals);
             self.add_manager_balance(allowance_1.asset, allowance_1.amount_decimals);
-            log_err(&format!(
-                "manager balance_0 {}, manager balance_1 {}",
-                allowance_0.amount_decimals, allowance_1.amount_decimals,
-            ));
         }
 
         let deposit_into_dex_result = self
             .deposit_into_dex(context, allowance_0, allowance_1)
             .await;
-
-        log_err("After depositing with failure into DEX");
-        self.with_balances_mut(|balances| {
-            log_err(&format!("asset_0_balance: {:#?}", balances.asset_0_balance));
-            log_err(&format!("asset_1_balance: {:#?}", balances.asset_1_balance));
-        });
 
         let returned_amounts_result = self
             .return_remaining_assets_to_owner(


### PR DESCRIPTION
After using bounded wait calls in < [Previous PR](https://github.com/dfinity/sns-kongswap-adaptor/pull/55) |, errors when calling `self.add_pool` can also be of time out type. Hence, we need to loose the pattern matching to cover them as well.